### PR TITLE
Bare activate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     rlang,
     tibble,
     tidyr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Suggests: ggplot2,
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tidync dev
+
+* Can now activate with a bare variable name. As per https://github.com/ropensci/tidync/issues/95
+
+
 # tidync 0.2.3
 
 * Remove test burden. 

--- a/R/activate.R
+++ b/R/activate.R
@@ -70,7 +70,10 @@ activate.tidync <- function(.data, what, ..., select_var = NULL) {
   } else if (what %in% .data$variable$name){
     if (!is.null(select_var)) {
       vargrids <- vargrids[vargrids$variable == select_var, , drop = FALSE]
+    } else {
+      vargrids <- vargrids[vargrids$variable == what, , drop = FALSE]
     }
+    
     what <- vargrids$grid[1L]
   }
 

--- a/R/activate.R
+++ b/R/activate.R
@@ -71,7 +71,7 @@ activate.tidync <- function(.data, what, ..., select_var = NULL) {
     if (!is.null(select_var)) {
       vargrids <- vargrids[vargrids$variable == select_var, , drop = FALSE]
     } else {
-      vargrids <- vargrids[vargrids$variable == what, , drop = FALSE]
+      vargrids <- vargrids[vargrids$variable == what[1], , drop = FALSE]
     }
     
     what <- vargrids$grid[1L]

--- a/man/hyper_array.Rd
+++ b/man/hyper_array.Rd
@@ -8,17 +8,34 @@
 \alias{hyper_array.character}
 \title{Extract NetCDF data as an array}
 \usage{
-hyper_array(x, select_var = NULL, ..., raw_datavals = FALSE,
-  force = FALSE, drop = TRUE)
+hyper_array(
+  x,
+  select_var = NULL,
+  ...,
+  raw_datavals = FALSE,
+  force = FALSE,
+  drop = TRUE
+)
 
-hyper_slice(x, select_var = NULL, ..., raw_datavals = FALSE,
-  force = FALSE, drop = TRUE)
+hyper_slice(
+  x,
+  select_var = NULL,
+  ...,
+  raw_datavals = FALSE,
+  force = FALSE,
+  drop = TRUE
+)
 
-\method{hyper_array}{tidync}(x, select_var = NULL, ...,
-  raw_datavals = FALSE, force = FALSE, drop = TRUE)
+\method{hyper_array}{tidync}(
+  x,
+  select_var = NULL,
+  ...,
+  raw_datavals = FALSE,
+  force = FALSE,
+  drop = TRUE
+)
 
-\method{hyper_array}{character}(x, select_var = NULL, ...,
-  raw_datavals = FALSE, drop = TRUE)
+\method{hyper_array}{character}(x, select_var = NULL, ..., raw_datavals = FALSE, drop = TRUE)
 }
 \arguments{
 \item{x}{NetCDF file, connection object, or \link{tidync} object}

--- a/man/tidync.Rd
+++ b/man/tidync.Rd
@@ -22,7 +22,7 @@ tidync(x, what, ...)
 \item{...}{reserved for arguments to methods, currently ignored}
 }
 \description{
-Connect to a NetCDF source and allow use of \code{hyper_*} verbs for slicing with
+Connect to a NetCDF source and allow use of \verb{hyper_*} verbs for slicing with
 \code{\link[=hyper_filter]{hyper_filter()}}, extracting data with \code{\link[=hyper_array]{hyper_array()}} and  [hyper_tibble()
 from an activated grid. By default the largest \emph{grid} encountered is
 activated, see\code{\link[=activate]{activate()}}.


### PR DESCRIPTION
Allow activation by variable *value*: 

```R
filename <- system.file("extdata/argo/MD5903593_001.nc", mustWork = TRUE, package = "tidync")
tidync(filename) %>% activate(JULD)
```

This now also works: 

```R
filename <- system.file("extdata/argo/MD5903593_001.nc", mustWork = TRUE, package = "tidync")
tidync(filename) %>% activate("JULD")
```

See https://github.com/ropensci/tidync/issues/95