### PR TITLE
Enable grid activation by using a variable name as a string

### DIFF
--- a/R/activate.R
+++ b/R/activate.R
@@ -61,7 +61,10 @@ activate.tidync <- function(.data, what, ..., select_var = NULL) {
   } else {
    vargrids <- tidyr::unnest(.data$grid) 
   }
-  what_name <- deparse(substitute(what))
+  # Try to set what_name to what (in case it's a string)
+  what_name <- try(what, silent = T)
+  # If it fails, use deparse(substitute(what)) to turn into string
+  if (class(what_name) == "try-error") what_name <- deparse(substitute(what))
   #if (what_name %in% var_names(.data)) what <- what_name
   if (what_name %in% vargrids$variable) {
     ## use the variable to find the grid


### PR DESCRIPTION
## Description
This pull request enables to pass a variable name as a string in order to activate the respective grid. It first tries to simply match `what_name` with `what`, which works if `what` is provided as a string. If this throws an error it executes the usual `deparse(substitute(what))` as before.

## Related Issue
This fixes #95

## Example
Try it out for any NetCDF file, where the variable you're trying to get is defined on a grid that is not activated by default.